### PR TITLE
fix end of line problem on windows

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,12 @@
   "plugins": ["unicorn", "import", "prettier", "node"],
   "settings": {},
   "rules": {
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ],
     // Mainly to make sure that the imports will always resolve
     "import/no-unresolved": [2, { "caseSensitive": true }],
     //These three are kind of annoying so turned them off


### PR DESCRIPTION
# Description

On Windows, an error was occurring at the end of every line with a red squiggly under a blank space

<!-- Please include a summary of the change -->

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Infrastructure

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. For example:
 - Ran locally
 - manually hit route in postman
 - Added unit test
 -->
 - Ran Locally

 ### New Environment Variables (if any)

<!-- Please include a list of any new environment variables introduced -->
-

### Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have written/modified relevant tests N/A
- [ ] All tests pass locally with my changes (`yarn test`) N/A